### PR TITLE
Fix port variable in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ from chatbot import generar_respuesta  # ✅ Importar la función correcta
 def obtener_puerto():
     return int(os.getenv("PORT", 8501))
 
+# Obtener y almacenar el puerto al iniciar la aplicación
+port = obtener_puerto()
+
 # Configuración de la interfaz con Streamlit
 st.set_page_config(page_title="Chatbot Wiki - Entra ID", layout="wide")
 st.title("🤖 Chatbot Wiki - Entra ID")


### PR DESCRIPTION
## Summary
- define `port` by calling `obtener_puerto`
- ensure port variable is used when displaying running port

## Testing
- `python -m py_compile app.py chatbot.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'langchain_chroma')*

------
https://chatgpt.com/codex/tasks/task_e_683f876d50c4833292dc349c21cee63f