### PR TITLE
Fix login instruction colon spacing

### DIFF
--- a/ayudas.txt
+++ b/ayudas.txt
@@ -3,7 +3,7 @@
 python -m huggingface_hub.cli login
 python -c "import huggingface_hub; print(huggingface_hub.__version__)"
 
-login si no funciona : 
+login si no funciona:
 
 python -c "from huggingface_hub import login; login()"
 


### PR DESCRIPTION
## Summary
- fix formatting in `ayudas.txt` by removing the space before the colon in line 6

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f8766b50883329738fa701dc2aa7f